### PR TITLE
Fix issue that ens addresses can be stale

### DIFF
--- a/packages/app/src/components/shared/FormattedAddress.tsx
+++ b/packages/app/src/components/shared/FormattedAddress.tsx
@@ -29,16 +29,20 @@ export default function FormattedAddress({
       try {
         const name = await readProvider.lookupAddress(address)
 
-        if (!name) return
+        if (!name) {
+          setEnsName(undefined);
+          return;
+        }
 
         // Reverse lookup to check validity
         const isValid =
           (await (await readProvider.resolveName(name)).toLowerCase()) ===
           address.toLowerCase()
 
-        if (isValid) setEnsName(name)
+        setEnsName(isValid ? name : undefined)
       } catch (e) {
         console.log('Error looking up ENS name for address', address, e)
+        setEnsName(undefined);
       }
     }
 


### PR DESCRIPTION
In some of the error paths, the ENS address is not reset - thus if there is an error, the ENS can be stale.