### PR TITLE
Pull shadow into CardSection component

### DIFF
--- a/packages/app/src/components/Dashboard/FundingCycles.tsx
+++ b/packages/app/src/components/Dashboard/FundingCycles.tsx
@@ -66,7 +66,7 @@ export default function FundingCycles({
       break
     case 'history':
       tabContent = (
-        <CardSection padded>
+        <CardSection>
           <FundingHistory startId={currentFC?.basedOn} />
         </CardSection>
       )

--- a/packages/app/src/components/FundingCycle/CurrentFundingCycle.tsx
+++ b/packages/app/src/components/FundingCycle/CurrentFundingCycle.tsx
@@ -23,13 +23,13 @@ export default function CurrentFundingCycle({
 
   return (
     <div style={{ position: 'relative' }}>
-      <CardSection padded style={{ marginBottom: 10 }}>
+      <CardSection padded>
         <FundingCyclePreview
           fundingCycle={currentFC}
           showDetail={showCurrentDetail}
         />
       </CardSection>
-      <CardSection padded style={{ marginBottom: 10 }}>
+      <CardSection padded>
         <Spending payoutMods={currentPayoutMods} />
       </CardSection>
       <CardSection padded>

--- a/packages/app/src/components/FundingCycle/CurrentFundingCycle.tsx
+++ b/packages/app/src/components/FundingCycle/CurrentFundingCycle.tsx
@@ -23,16 +23,16 @@ export default function CurrentFundingCycle({
 
   return (
     <div style={{ position: 'relative' }}>
-      <CardSection padded>
+      <CardSection>
         <FundingCyclePreview
           fundingCycle={currentFC}
           showDetail={showCurrentDetail}
         />
       </CardSection>
-      <CardSection padded>
+      <CardSection>
         <Spending payoutMods={currentPayoutMods} />
       </CardSection>
-      <CardSection padded>
+      <CardSection>
         <ReservedTokens
           fundingCycle={currentFC}
           ticketMods={currentTicketMods}

--- a/packages/app/src/components/FundingCycle/QueuedFundingCycle.tsx
+++ b/packages/app/src/components/FundingCycle/QueuedFundingCycle.tsx
@@ -28,10 +28,10 @@ export default function QueuedFundingCycle() {
       {queuedFC?.number.gt(0) ? (
         hasFundingTarget(queuedFC) ? (
           <div style={{ position: 'relative' }}>
-            <CardSection padded style={{ marginBottom: 10 }}>
+            <CardSection padded>
               <FundingCycleDetails fundingCycle={queuedFC} />
             </CardSection>
-            <CardSection padded style={{ marginBottom: 10 }}>
+            <CardSection padded>
               <PayoutModsList
                 mods={queuedPayoutMods}
                 fundingCycle={queuedFC}

--- a/packages/app/src/components/FundingCycle/QueuedFundingCycle.tsx
+++ b/packages/app/src/components/FundingCycle/QueuedFundingCycle.tsx
@@ -28,10 +28,10 @@ export default function QueuedFundingCycle() {
       {queuedFC?.number.gt(0) ? (
         hasFundingTarget(queuedFC) ? (
           <div style={{ position: 'relative' }}>
-            <CardSection padded>
+            <CardSection>
               <FundingCycleDetails fundingCycle={queuedFC} />
             </CardSection>
-            <CardSection padded>
+            <CardSection>
               <PayoutModsList
                 mods={queuedPayoutMods}
                 fundingCycle={queuedFC}
@@ -39,7 +39,7 @@ export default function QueuedFundingCycle() {
                 isOwner={isOwner}
               />
             </CardSection>
-            <CardSection padded>
+            <CardSection>
               <ReservedTokens
                 fundingCycle={queuedFC}
                 ticketMods={queuedTicketMods}

--- a/packages/app/src/components/shared/CardSection.tsx
+++ b/packages/app/src/components/shared/CardSection.tsx
@@ -6,17 +6,21 @@ import { CSSProperties, useContext } from 'react'
 export function CardSection({
   header,
   padded,
+  noFooter,
   children,
   style,
 }: {
   header?: string
   padded?: boolean
+  noFooter?: boolean
   children?: ChildElems
   style?: CSSProperties
 }) {
   const { theme } = useContext(ThemeContext)
   return (
-    <div>
+    <div style={{
+      marginBottom: (noFooter ? 0 : 10)
+    }}>
       {header && (
         <h2
           style={{

--- a/packages/app/src/components/shared/CardSection.tsx
+++ b/packages/app/src/components/shared/CardSection.tsx
@@ -6,20 +6,20 @@ import { CSSProperties, useContext } from 'react'
 export function CardSection({
   header,
   padded,
-  noFooter,
+  noShadow,
   children,
   style,
 }: {
   header?: string
   padded?: boolean
-  noFooter?: boolean
+  noShadow?: boolean
   children?: ChildElems
   style?: CSSProperties
 }) {
   const { theme } = useContext(ThemeContext)
   return (
     <div style={{
-      marginBottom: (noFooter ? 0 : 10)
+      marginBottom: (noShadow ? 0 : 10)
     }}>
       {header && (
         <h2

--- a/packages/app/src/components/shared/CardSection.tsx
+++ b/packages/app/src/components/shared/CardSection.tsx
@@ -5,7 +5,7 @@ import { CSSProperties, useContext } from 'react'
 
 export function CardSection({
   header,
-  padded,
+  padded = true,
   noShadow,
   children,
   style,


### PR DESCRIPTION
From what I can tell, we pretty much always apply this 10px margin to account for the card shadow. We can just pull this into the component and create an option to not show it if consumers of the API want to chain together multiple CardSection(s).

We also always use padded = true, so I made this the default.