### PR TITLE
Feature/operator permissions

### DIFF
--- a/packages/app/src/components/Create/ConfirmDeployProject.tsx
+++ b/packages/app/src/components/Create/ConfirmDeployProject.tsx
@@ -113,7 +113,6 @@ export default function ConfirmDeployProject() {
             mods={payoutMods}
             projectId={undefined}
             fundingCycle={editingFC}
-            isOwner={true}
           />
         )}
       />
@@ -124,7 +123,6 @@ export default function ConfirmDeployProject() {
             mods={ticketMods}
             projectId={undefined}
             fundingCycle={undefined}
-            isOwner={true}
           />
         )}
       />

--- a/packages/app/src/components/Create/index.tsx
+++ b/packages/app/src/components/Create/index.tsx
@@ -329,7 +329,6 @@ export default function Create() {
         createdAt: new Date().valueOf() / 1000,
         projectType: 'standard',
         owner: userAddress,
-        isOwner: false,
         currentFC: fundingCycle,
         currentPayoutMods: editingPayoutMods,
         currentTicketMods: editingTicketMods,

--- a/packages/app/src/components/Dashboard/FundingCycles.tsx
+++ b/packages/app/src/components/Dashboard/FundingCycles.tsx
@@ -3,6 +3,7 @@ import ReconfigureFCModal from 'components/modals/ReconfigureFCModal'
 import { CardSection } from 'components/shared/CardSection'
 import { ProjectContext } from 'contexts/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
+import { OperatorPermission, useHasPermission } from 'hooks/HasPermission'
 import { useContext, useState } from 'react'
 
 import CurrentFundingCycle from '../FundingCycle/CurrentFundingCycle'
@@ -25,7 +26,6 @@ export default function FundingCycles({
   const {
     projectId,
     currentFC,
-    isOwner,
     queuedFC,
     queuedPayoutMods,
     queuedTicketMods,
@@ -73,6 +73,8 @@ export default function FundingCycles({
       break
   }
 
+  const canReconfigure = useHasPermission(OperatorPermission.Configure)
+
   if (!projectId) return null
 
   return (
@@ -99,7 +101,7 @@ export default function FundingCycles({
       </div>
       <div>{tabContent}</div>
 
-      {isOwner && (
+      {canReconfigure && (
         <Button
           style={{ marginTop: 20 }}
           onClick={() => setReconfigureModalVisible(true)}

--- a/packages/app/src/components/Dashboard/Project.tsx
+++ b/packages/app/src/components/Dashboard/Project.tsx
@@ -2,6 +2,7 @@ import { BigNumber } from '@ethersproject/bignumber'
 import { Col, Row, Space } from 'antd'
 import { ProjectContext } from 'contexts/projectContext'
 import useContractReader from 'hooks/ContractReader'
+import { OperatorPermission, useHasPermission } from 'hooks/HasPermission'
 import { ContractName } from 'models/contract-name'
 import { CSSProperties, useContext, useMemo } from 'react'
 import { bigNumbersDiff } from 'utils/bigNumbersDiff'
@@ -22,13 +23,17 @@ export default function Project({
   style?: CSSProperties
   showCurrentDetail?: boolean
 }) {
-  const { projectId, isOwner } = useContext(ProjectContext)
+  const { projectId } = useContext(ProjectContext)
 
   const canPrintPreminedTickets = useContractReader<boolean>({
     contract: ContractName.TerminalV1,
     functionName: 'canPrintPreminedTickets',
     args: projectId ? [projectId.toHexString()] : null,
   })
+
+  const hasPrintPreminePermission = useHasPermission(
+    OperatorPermission.PrintPreminedTickets,
+  )
 
   const totalOverflow = useContractReader<BigNumber>({
     contract: ContractName.TerminalV1,
@@ -70,7 +75,7 @@ export default function Project({
 
         <Col xs={24} md={12} style={{ marginTop: gutter }}>
           <Space direction="vertical" style={{ width: '100%' }} size="large">
-            {canPrintPreminedTickets && isOwner && (
+            {canPrintPreminedTickets && hasPrintPreminePermission && (
               <PrintPremined projectId={projectId} />
             )}
             <Pay />

--- a/packages/app/src/components/Dashboard/ProjectHeader.tsx
+++ b/packages/app/src/components/Dashboard/ProjectHeader.tsx
@@ -5,6 +5,7 @@ import ProjectToolDrawerModal from 'components/modals/ProjectToolDrawerModal'
 import ProjectLogo from 'components/shared/ProjectLogo'
 import { ProjectContext } from 'contexts/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
+import { OperatorPermission, useHasPermission } from 'hooks/HasPermission'
 import { useContext, useState } from 'react'
 
 export default function ProjectHeader() {
@@ -12,13 +13,18 @@ export default function ProjectHeader() {
     useState<boolean>(false)
   const [toolDrawerVisible, setToolDrawerVisible] = useState<boolean>(false)
 
-  const { projectId, handle, metadata, isOwner } = useContext(ProjectContext)
+  const { projectId, handle, metadata } = useContext(ProjectContext)
 
   const {
     theme: { colors },
   } = useContext(ThemeContext)
 
   const headerHeight = 120
+
+  const hasEditPermission = useHasPermission([
+    OperatorPermission.SetHandle,
+    OperatorPermission.SetUri,
+  ])
 
   if (!projectId) return null
 
@@ -104,7 +110,7 @@ export default function ProjectHeader() {
                 icon={<ToolOutlined />}
                 type="text"
               ></Button>
-              {isOwner && (
+              {hasEditPermission && (
                 <Button
                   onClick={() => setEditProjectModalVisible(true)}
                   icon={<SettingOutlined />}

--- a/packages/app/src/components/Dashboard/ReservedTokens.tsx
+++ b/packages/app/src/components/Dashboard/ReservedTokens.tsx
@@ -27,7 +27,7 @@ export default function ReservedTokens({
   const [modalIsVisible, setModalIsVisible] = useState<boolean>()
   const { userAddress } = useContext(NetworkContext)
 
-  const { projectId, isOwner, tokenSymbol } = useContext(ProjectContext)
+  const { projectId, tokenSymbol } = useContext(ProjectContext)
 
   const metadata = decodeFCMetadata(fundingCycle?.metadata)
 
@@ -95,7 +95,6 @@ export default function ReservedTokens({
         mods={ticketMods}
         fundingCycle={fundingCycle}
         projectId={projectId}
-        isOwner={isOwner}
       />
 
       {!hideActions && (

--- a/packages/app/src/components/Dashboard/Rewards.tsx
+++ b/packages/app/src/components/Dashboard/Rewards.tsx
@@ -1,18 +1,19 @@
 import { BigNumber } from '@ethersproject/bignumber'
-import { Button, Descriptions, Space, Statistic, Tooltip } from 'antd'
+import { Button, Descriptions, Space, Statistic } from 'antd'
 import Modal from 'antd/lib/modal/Modal'
 import ConfirmStakeTokensModal from 'components/modals/ConfirmStakeTokensModal'
 import ConfirmUnstakeTokensModal from 'components/modals/ConfirmUnstakeTokensModal'
 import CurrencySymbol from 'components/shared/CurrencySymbol'
 import InputAccessoryButton from 'components/shared/InputAccessoryButton'
 import FormattedNumberInput from 'components/shared/inputs/FormattedNumberInput'
+import { NetworkContext } from 'contexts/networkContext'
 import { ProjectContext } from 'contexts/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
 import { UserContext } from 'contexts/userContext'
-import { NetworkContext } from 'contexts/networkContext'
 import { constants } from 'ethers'
 import useContractReader, { ContractUpdateOn } from 'hooks/ContractReader'
 import { useErc20Contract } from 'hooks/Erc20Contract'
+import { OperatorPermission, useHasPermission } from 'hooks/HasPermission'
 import { ContractName } from 'models/contract-name'
 import { useContext, useMemo, useState } from 'react'
 import { bigNumbersDiff } from 'utils/bigNumbersDiff'
@@ -31,8 +32,7 @@ export default function Rewards({
   const { contracts, transactor } = useContext(UserContext)
   const { userAddress } = useContext(NetworkContext)
 
-  const { projectId, isOwner, tokenAddress, tokenSymbol } =
-    useContext(ProjectContext)
+  const { projectId, tokenAddress, tokenSymbol } = useContext(ProjectContext)
 
   const {
     theme: { colors },
@@ -201,6 +201,8 @@ export default function Rewards({
     ? tokenAddress !== constants.AddressZero
     : undefined
 
+  const hasIssueTicketsPermission = useHasPermission(OperatorPermission.Issue)
+
   return (
     <div>
       <Space direction="vertical" size="large">
@@ -303,7 +305,9 @@ export default function Rewards({
           )}
         />
 
-        {!ticketsIssued && isOwner && <IssueTickets projectId={projectId} />}
+        {!ticketsIssued && hasIssueTicketsPermission && (
+          <IssueTickets projectId={projectId} />
+        )}
       </Space>
 
       <Modal

--- a/packages/app/src/components/Dashboard/Spending.tsx
+++ b/packages/app/src/components/Dashboard/Spending.tsx
@@ -23,7 +23,7 @@ export default function Spending({
     theme: { colors },
   } = useContext(ThemeContext)
 
-  const { balanceInCurrency, projectId, isOwner, owner, currentFC } =
+  const { balanceInCurrency, projectId, owner, currentFC } =
     useContext(ProjectContext)
 
   const [withdrawModalVisible, setWithdrawModalVisible] = useState<boolean>()
@@ -114,7 +114,6 @@ export default function Spending({
             mods={payoutMods}
             fundingCycle={currentFC}
             projectId={projectId}
-            isOwner={isOwner}
           />
         </div>
       </Space>

--- a/packages/app/src/components/Dashboard/index.tsx
+++ b/packages/app/src/components/Dashboard/index.tsx
@@ -2,7 +2,6 @@ import { BigNumber } from '@ethersproject/bignumber'
 import { projectTypes } from 'constants/project-types'
 import { layouts } from 'constants/styles/layouts'
 import { padding } from 'constants/styles/padding'
-import { NetworkContext } from 'contexts/networkContext'
 import { ProjectContext } from 'contexts/projectContext'
 import { utils } from 'ethers'
 import useContractReader from 'hooks/ContractReader'
@@ -14,7 +13,7 @@ import { CurrencyOption } from 'models/currency-option'
 import { FundingCycle } from 'models/funding-cycle'
 import { PayoutMod, TicketMod } from 'models/mods'
 import { parseProjectJson } from 'models/subgraph-entities/project'
-import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { bigNumbersDiff } from 'utils/bigNumbersDiff'
 import { deepEqFundingCycles } from 'utils/deepEqFundingCycles'
@@ -29,8 +28,6 @@ export default function Dashboard() {
   const [createdAt, setCreatedAt] = useState<number>()
 
   const converter = useCurrencyConverter()
-
-  const { userAddress } = useContext(NetworkContext)
 
   const { handle }: { handle?: string } = useParams()
 
@@ -279,17 +276,6 @@ export default function Dashboard() {
     [currentFC?.currency, balance, converter],
   )
 
-  // const canSetPayoutMods = useContractReader<string>({
-  //   contract: ContractName.OperatorStore,
-  //   functionName: 'hasPermission',
-  //   args:
-  //     userAddress && owner && projectId
-  //       ? [userAddress, owner, projectId.toHexString(), 14]
-  //       : null,
-  // })
-
-  const isOwner = userAddress?.toLowerCase() === owner?.toLowerCase()
-
   if (projectExists === undefined) return <Loading />
 
   if (!projectExists) {
@@ -317,7 +303,6 @@ export default function Dashboard() {
         projectId,
         projectType,
         owner,
-        isOwner,
         handle,
         metadata,
         currentFC,

--- a/packages/app/src/components/FundingCycle/QueuedFundingCycle.tsx
+++ b/packages/app/src/components/FundingCycle/QueuedFundingCycle.tsx
@@ -4,22 +4,17 @@ import { ThemeContext } from 'contexts/themeContext'
 import { useContext } from 'react'
 import { hasFundingTarget } from 'utils/fundingCycle'
 
-import FundingCycleDetails from './FundingCycleDetails'
-import PayoutModsList from '../shared/PayoutModsList'
 import ReservedTokens from '../Dashboard/ReservedTokens'
+import PayoutModsList from '../shared/PayoutModsList'
+import FundingCycleDetails from './FundingCycleDetails'
 
 export default function QueuedFundingCycle() {
   const {
     theme: { colors },
   } = useContext(ThemeContext)
 
-  const {
-    projectId,
-    isOwner,
-    queuedFC,
-    queuedPayoutMods,
-    queuedTicketMods,
-  } = useContext(ProjectContext)
+  const { projectId, queuedFC, queuedPayoutMods, queuedTicketMods } =
+    useContext(ProjectContext)
 
   if (!projectId) return null
 
@@ -36,7 +31,6 @@ export default function QueuedFundingCycle() {
                 mods={queuedPayoutMods}
                 fundingCycle={queuedFC}
                 projectId={projectId}
-                isOwner={isOwner}
               />
             </CardSection>
             <CardSection>

--- a/packages/app/src/components/modals/DistributeTokensModal.tsx
+++ b/packages/app/src/components/modals/DistributeTokensModal.tsx
@@ -1,7 +1,7 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { Modal, Space } from 'antd'
-import TicketModsList from 'components/shared/TicketModsList'
 import FormattedAddress from 'components/shared/FormattedAddress'
+import TicketModsList from 'components/shared/TicketModsList'
 import { ProjectContext } from 'contexts/projectContext'
 import { UserContext } from 'contexts/userContext'
 import useContractReader from 'hooks/ContractReader'
@@ -84,7 +84,6 @@ export default function DistributeTokensModal({
               mods={currentTicketMods}
               fundingCycle={currentFC}
               projectId={projectId}
-              isOwner={false}
             />
           </div>
         ) : (

--- a/packages/app/src/components/modals/ReconfigureFCModal.tsx
+++ b/packages/app/src/components/modals/ReconfigureFCModal.tsx
@@ -377,7 +377,6 @@ export default function ReconfigureFCModal({
               mods={editingPayoutMods}
               projectId={undefined}
               fundingCycle={editingFC}
-              isOwner={true}
             />
           </div>
 
@@ -387,7 +386,6 @@ export default function ReconfigureFCModal({
               mods={editingTicketMods}
               projectId={undefined}
               fundingCycle={undefined}
-              isOwner={true}
             />
           </div>
         </Space>

--- a/packages/app/src/components/modals/WithdrawModal.tsx
+++ b/packages/app/src/components/modals/WithdrawModal.tsx
@@ -183,7 +183,6 @@ export default function WithdrawModal({
               mods={currentPayoutMods}
               fundingCycle={currentFC}
               projectId={projectId}
-              isOwner={false}
             />
           </div>
         ) : (

--- a/packages/app/src/components/shared/PayoutModsList.tsx
+++ b/packages/app/src/components/shared/PayoutModsList.tsx
@@ -4,6 +4,7 @@ import Mod from 'components/shared/Mod'
 import { ProjectContext } from 'contexts/projectContext'
 import { UserContext } from 'contexts/userContext'
 import { BigNumber, constants } from 'ethers'
+import { OperatorPermission, useHasPermission } from 'hooks/HasPermission'
 import { CurrencyOption } from 'models/currency-option'
 import { FundingCycle } from 'models/funding-cycle'
 import { PayoutMod } from 'models/mods'
@@ -17,7 +18,6 @@ export default function PayoutModsList({
   mods,
   fundingCycle,
   projectId,
-  isOwner,
   total,
 }: {
   mods: PayoutMod[] | undefined
@@ -25,7 +25,6 @@ export default function PayoutModsList({
     | Pick<FundingCycle, 'target' | 'currency' | 'configured' | 'fee'>
     | undefined
   projectId: BigNumber | undefined
-  isOwner: boolean | undefined
   total?: BigNumber
 }) {
   const [modalVisible, setModalVisible] = useState<boolean>(false)
@@ -88,6 +87,8 @@ export default function PayoutModsList({
 
   const baseTotal =
     total ?? amountSubFee(fundingCycle?.target, fundingCycle?.fee)
+
+  const hasEditPermission = useHasPermission(OperatorPermission.SetPayoutMods)
 
   if (!fundingCycle) return null
 
@@ -156,7 +157,7 @@ export default function PayoutModsList({
         />
       )}
 
-      {fundingCycle && projectId?.gt(0) && isOwner ? (
+      {fundingCycle && projectId?.gt(0) && hasEditPermission ? (
         <div style={{ marginTop: 10 }}>
           <Button size="small" onClick={() => setModalVisible(true)}>
             Edit payouts

--- a/packages/app/src/components/shared/TicketModsList.tsx
+++ b/packages/app/src/components/shared/TicketModsList.tsx
@@ -4,6 +4,7 @@ import Mod from 'components/shared/Mod'
 import { ProjectContext } from 'contexts/projectContext'
 import { UserContext } from 'contexts/userContext'
 import { BigNumber, constants } from 'ethers'
+import { OperatorPermission, useHasPermission } from 'hooks/HasPermission'
 import { FundingCycle } from 'models/funding-cycle'
 import { TicketMod } from 'models/mods'
 import { useContext, useLayoutEffect, useMemo, useState } from 'react'
@@ -14,13 +15,11 @@ export default function TicketModsList({
   mods,
   fundingCycle,
   projectId,
-  isOwner,
 }: {
   total?: BigNumber
   mods: TicketMod[] | undefined
   fundingCycle: FundingCycle | undefined
   projectId: BigNumber | undefined
-  isOwner: boolean | undefined
 }) {
   const [modalVisible, setModalVisible] = useState<boolean>(false)
   const [loading, setLoading] = useState<boolean>(false)
@@ -78,6 +77,8 @@ export default function TicketModsList({
   const modsTotal = mods?.reduce((acc, curr) => acc + curr.percent, 0)
   const ownerPercent = 10000 - (modsTotal ?? 0)
 
+  const hasEditPermission = useHasPermission(OperatorPermission.SetTicketMods)
+
   return (
     <div>
       {mods?.length
@@ -120,7 +121,7 @@ export default function TicketModsList({
         />
       )}
 
-      {fundingCycle && projectId?.gt(0) && isOwner ? (
+      {fundingCycle && projectId?.gt(0) && hasEditPermission ? (
         <div style={{ marginTop: 10 }}>
           <Button size="small" onClick={() => setModalVisible(true)}>
             Edit token receivers

--- a/packages/app/src/contexts/projectContext.ts
+++ b/packages/app/src/contexts/projectContext.ts
@@ -12,7 +12,6 @@ export type ProjectContext = {
   handle: string | undefined
   metadata: ProjectMetadata | undefined
   owner: string | undefined // owner address
-  isOwner: boolean | undefined // connected user is owner
   currentFC: FundingCycle | undefined
   queuedFC: FundingCycle | undefined
   currentPayoutMods: PayoutMod[] | undefined
@@ -31,7 +30,6 @@ export const ProjectContext = createContext<ProjectContext>({
   handle: undefined,
   metadata: undefined,
   owner: undefined,
-  isOwner: undefined,
   currentFC: undefined,
   queuedFC: undefined,
   currentPayoutMods: undefined,

--- a/packages/app/src/hooks/HasPermission.tsx
+++ b/packages/app/src/hooks/HasPermission.tsx
@@ -44,5 +44,8 @@ export function useHasPermission(
         : null,
   })
 
-  return userAddress === owner || hasOperatorPermission
+  const isOwner =
+    userAddress && owner && userAddress.toLowerCase() === owner.toLowerCase()
+
+  return isOwner || hasOperatorPermission
 }

--- a/packages/app/src/hooks/HasPermission.tsx
+++ b/packages/app/src/hooks/HasPermission.tsx
@@ -1,0 +1,48 @@
+import { NetworkContext } from 'contexts/networkContext'
+import { ProjectContext } from 'contexts/projectContext'
+import { ContractName } from 'models/contract-name'
+import { useContext } from 'react'
+
+import useContractReader from './ContractReader'
+
+export enum OperatorPermission {
+  'Configure' = 1,
+  'PrintPreminedTickets' = 2,
+  'Redeem' = 3,
+  'Migrate' = 4,
+  'SetHandle' = 5,
+  'SetUri' = 6,
+  'ClaimHandle' = 7,
+  'RenewHandle' = 8,
+  'Issue' = 9,
+  'Stake' = 10,
+  'Unstake' = 11,
+  'Transfer' = 12,
+  'Lock' = 13,
+  'SetPayoutMods' = 14,
+  'SetTicketMods' = 15,
+  'SetTerminal' = 16,
+}
+
+export function useHasPermission(
+  permission: OperatorPermission | OperatorPermission[],
+) {
+  const { userAddress } = useContext(NetworkContext)
+  const { projectId, owner } = useContext(ProjectContext)
+
+  const hasOperatorPermission = useContractReader<boolean>({
+    contract: ContractName.OperatorStore,
+    functionName: 'hasPermissions',
+    args:
+      userAddress && owner && projectId
+        ? [
+            userAddress,
+            owner,
+            projectId.toHexString(),
+            ...(Array.isArray(permission) ? permission : [permission]),
+          ]
+        : null,
+  })
+
+  return userAddress === owner || hasOperatorPermission
+}

--- a/packages/app/src/models/contract-name.ts
+++ b/packages/app/src/models/contract-name.ts
@@ -3,6 +3,7 @@ export enum ContractName {
   FundingCycles = 'FundingCycles',
   TerminalV1 = 'TerminalV1',
   ModStore = 'ModStore',
+  OperatorStore = 'OperatorStore',
   Prices = 'Prices',
   Projects = 'Projects',
   TicketBooth = 'TicketBooth',


### PR DESCRIPTION
New hasPermissions hook allows easily checking if the connected wallet has been granted specific permissions as an operator

Deprecates the `isOwner` value from ProjectContext